### PR TITLE
Добавлена поддержка отслеживания установки версий ФИАС

### DIFF
--- a/Libs/YPermitin.FIASToolSet.Storage.Core/Models/FIASVersionInstallation.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.Core/Models/FIASVersionInstallation.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace YPermitin.FIASToolSet.Storage.Core.Models;
+
+/// <summary>
+/// Информация об установленной версии ФИАС
+/// </summary>
+public class FIASVersionInstallation
+{
+    /// <summary>
+    /// Идентификатор записи
+    /// </summary>
+    public Guid Id { get; set; }
+    
+    /// <summary>
+    /// Период создания
+    /// </summary>
+    public DateTime Created { get; set; }
+    
+    /// <summary>
+    /// Версия ФИАС
+    /// </summary>
+    [ForeignKey("FIASVersionId")]
+    public FIASVersion FIASVersion { get; set; }
+
+    /// <summary>
+    /// Идентификатор версии ФИАС
+    /// </summary>        
+    public Guid FIASVersionId { get; set; }
+    
+    /// <summary>
+    /// Версия ФИАС
+    /// </summary>
+    [ForeignKey("StatusId")]
+    public FIASVersionInstallationStatus Status { get; set; }
+
+    /// <summary>
+    /// Идентификатор версии ФИАС
+    /// </summary>        
+    public Guid StatusId { get; set; }
+    
+    /// <summary>
+    /// Тип установки ФИАС
+    /// </summary>
+    [ForeignKey("InstallationTypeId")]
+    public FIASVersionInstallationType InstallationType { get; set; }
+
+    /// <summary>
+    /// Идентификатор типа установки ФИАС
+    /// </summary>        
+    public Guid InstallationTypeId { get; set; }
+}

--- a/Libs/YPermitin.FIASToolSet.Storage.Core/Models/FIASVersionInstallationStatus.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.Core/Models/FIASVersionInstallationStatus.cs
@@ -1,0 +1,21 @@
+namespace YPermitin.FIASToolSet.Storage.Core.Models;
+
+/// <summary>
+/// Статус установки версии ФИАС
+/// </summary>
+public class FIASVersionInstallationStatus
+{
+    public static Guid New = new Guid("090cc6b8-a5c3-451c-b8fd-e5522ba9ce6a");
+    public static Guid Installing = new Guid("4dba445f-ff47-4071-b9ae-6d3c56d6fe7d");
+    public static Guid Installed = new Guid("b0473a78-2743-4f64-b2ea-683b97cc55c5");
+    
+    /// <summary>
+    /// Идентификатор статуса
+    /// </summary>
+    public Guid Id { get; set; }
+    
+    /// <summary>
+    /// Наименование статуса
+    /// </summary>
+    public string Name { get; set; }
+}

--- a/Libs/YPermitin.FIASToolSet.Storage.Core/Models/FIASVersionInstallationType.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.Core/Models/FIASVersionInstallationType.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace YPermitin.FIASToolSet.Storage.Core.Models;
+
+/// <summary>
+/// Тип установки версии ФИАС
+/// </summary>
+public class FIASVersionInstallationType
+{
+    public static Guid Full = new Guid("e4c31e19-cb2d-47cd-b96e-08a0876ac4f6");
+    public static Guid Update = new Guid("4dba445f-ff47-4071-b9ae-6d3c56d6fe7d");
+
+    /// <summary>
+    /// Идентификатор статуса
+    /// </summary>
+    public Guid Id { get; set; }
+    
+    /// <summary>
+    /// Наименование статуса
+    /// </summary>
+    public string Name { get; set; }
+}

--- a/Libs/YPermitin.FIASToolSet.Storage.Core/Services/IFIASInstallationManagerRepository.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.Core/Services/IFIASInstallationManagerRepository.cs
@@ -1,0 +1,18 @@
+using YPermitin.FIASToolSet.Storage.Core.Models;
+
+namespace YPermitin.FIASToolSet.Storage.Core.Services;
+
+public interface IFIASInstallationManagerRepository
+{
+    Task<List<FIASVersionInstallation>> GetInstallations(Guid? statusId = null, Guid? typeId = null);
+    Task<FIASVersionInstallation> GetInstallation(Guid id);
+    Task<FIASVersionInstallation> GetLastInstallation();
+    Task<FIASVersionInstallation> GetPreviousInstallation(Guid installationId);
+    void AddInstallation(FIASVersionInstallation installation);
+    void UpdateInstallation(FIASVersionInstallation installation);
+    
+    Task<bool> BeginTransactionAsync();
+    Task CommitTransactionAsync();
+    Task RollbackTransactionAsync();
+    Task<bool> SaveAsync();
+}

--- a/Libs/YPermitin.FIASToolSet.Storage.Core/YPermitin.FIASToolSet.Storage.Core.xml
+++ b/Libs/YPermitin.FIASToolSet.Storage.Core/YPermitin.FIASToolSet.Storage.Core.xml
@@ -74,6 +74,81 @@
             Файлы дистрибутива КЛАДР 4 в формате 7Z (полная база)
             </summary>
         </member>
+        <member name="T:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation">
+            <summary>
+            Информация об установленной версии ФИАС
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.Id">
+            <summary>
+            Идентификатор записи
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.Created">
+            <summary>
+            Период создания
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.FIASVersion">
+            <summary>
+            Версия ФИАС
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.FIASVersionId">
+            <summary>
+            Идентификатор версии ФИАС
+            </summary>        
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.Status">
+            <summary>
+            Версия ФИАС
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.StatusId">
+            <summary>
+            Идентификатор версии ФИАС
+            </summary>        
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.InstallationType">
+            <summary>
+            Тип установки ФИАС
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation.InstallationTypeId">
+            <summary>
+            Идентификатор типа установки ФИАС
+            </summary>        
+        </member>
+        <member name="T:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationStatus">
+            <summary>
+            Статус установки версии ФИАС
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationStatus.Id">
+            <summary>
+            Идентификатор статуса
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationStatus.Name">
+            <summary>
+            Наименование статуса
+            </summary>
+        </member>
+        <member name="T:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationType">
+            <summary>
+            Тип установки версии ФИАС
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationType.Id">
+            <summary>
+            Идентификатор статуса
+            </summary>
+        </member>
+        <member name="P:YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationType.Name">
+            <summary>
+            Наименование статуса
+            </summary>
+        </member>
         <member name="T:YPermitin.FIASToolSet.Storage.Core.Models.NotificationQueue">
             <summary>
             Элемент уведомления в общей очереди

--- a/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/DbContexts/FIASToolSetServiceContext.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/DbContexts/FIASToolSetServiceContext.cs
@@ -9,6 +9,10 @@ namespace YPermitin.FIASToolSet.Storage.PostgreSQL.DbContexts
         public DbSet<FIASVersion> FIASVersions { get; set; }
         public DbSet<NotificationQueue> NotificationsQueues { get; set; }
         public DbSet<NotificationStatus> NotificationsStatuses { get; set; }
+        
+        public DbSet<FIASVersionInstallationStatus> FIASVersionInstallationStatuses { get; set; }
+        public DbSet<FIASVersionInstallation> FIASVersionInstallations { get; set; }
+        public DbSet<FIASVersionInstallationType> FIASVersionInstallationsTypes { get; set; }
 
         private FIASToolSetServiceContext()
         {
@@ -105,6 +109,70 @@ namespace YPermitin.FIASToolSet.Storage.PostgreSQL.DbContexts
             modelBuilder.Entity<FIASVersion>()
                 .Property(e => e.TextVersion)
                 .HasMaxLength(50);
+
+            #endregion
+
+            #region FIASVersionInstallationStatus
+
+            modelBuilder.Entity<FIASVersionInstallationStatus>()
+                .HasKey(e => e.Id);
+            modelBuilder.Entity<FIASVersionInstallationStatus>()
+                .HasIndex(e => new { e.Id });
+            modelBuilder.Entity<FIASVersionInstallationStatus>()
+                .HasIndex(e => new { e.Name });
+            modelBuilder.Entity<FIASVersionInstallationStatus>()
+                .HasData(new List<FIASVersionInstallationStatus>()
+                {
+                    new()
+                    {
+                        Id = FIASVersionInstallationStatus.New,
+                        Name = "New"
+                    },
+                    new()
+                    {
+                        Id = FIASVersionInstallationStatus.Installing,
+                        Name = "Installing"
+                    },
+                    new()
+                    {
+                        Id = FIASVersionInstallationStatus.Installed,
+                        Name = "Installed"
+                    }
+                });
+
+            #endregion
+            
+            #region FIASVersionInstallation
+            
+            modelBuilder.Entity<FIASVersionInstallation>()
+                .HasKey(e => e.Id);
+            modelBuilder.Entity<FIASVersionInstallation>()
+                .HasIndex(e => new { e.Id });
+            modelBuilder.Entity<FIASVersionInstallation>()
+                .HasIndex(e => new { e.StatusId, e.Created, e.Id });
+
+            #endregion
+            
+            #region FIASVersionInstallationType
+            
+            modelBuilder.Entity<FIASVersionInstallationType>()
+                .HasKey(e => e.Id);
+            modelBuilder.Entity<FIASVersionInstallationType>()
+                .HasIndex(e => new { e.Id });
+            modelBuilder.Entity<FIASVersionInstallationType>()
+                .HasData(new List<FIASVersionInstallationType>()
+                {
+                    new()
+                    {
+                        Id = FIASVersionInstallationType.Full,
+                        Name = "Full"
+                    },
+                    new()
+                    {
+                        Id = FIASVersionInstallationType.Update,
+                        Name = "Update"
+                    }
+                });
 
             #endregion
         }

--- a/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/Migrations/FIASToolSetServiceContextModelSnapshot.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/Migrations/FIASToolSetServiceContextModelSnapshot.cs
@@ -72,6 +72,100 @@ namespace YPermitin.FIASToolSet.Storage.PostgreSQL.Migrations
                     b.ToTable("FIASVersions");
                 });
 
+            modelBuilder.Entity("YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("Created")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<Guid>("FIASVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("InstallationTypeId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("StatusId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("FIASVersionId");
+
+                    b.HasIndex("Id");
+
+                    b.HasIndex("InstallationTypeId");
+
+                    b.HasIndex("StatusId", "Created", "Id");
+
+                    b.ToTable("FIASVersionInstallations");
+                });
+
+            modelBuilder.Entity("YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationStatus", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Name")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Id");
+
+                    b.HasIndex("Name");
+
+                    b.ToTable("FIASVersionInstallationStatuses");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("090cc6b8-a5c3-451c-b8fd-e5522ba9ce6a"),
+                            Name = "New"
+                        },
+                        new
+                        {
+                            Id = new Guid("4dba445f-ff47-4071-b9ae-6d3c56d6fe7d"),
+                            Name = "Installing"
+                        },
+                        new
+                        {
+                            Id = new Guid("b0473a78-2743-4f64-b2ea-683b97cc55c5"),
+                            Name = "Installed"
+                        });
+                });
+
+            modelBuilder.Entity("YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationType", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Name")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Id");
+
+                    b.ToTable("FIASVersionInstallationsTypes");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("e4c31e19-cb2d-47cd-b96e-08a0876ac4f6"),
+                            Name = "Full"
+                        },
+                        new
+                        {
+                            Id = new Guid("4dba445f-ff47-4071-b9ae-6d3c56d6fe7d"),
+                            Name = "Update"
+                        });
+                });
+
             modelBuilder.Entity("YPermitin.FIASToolSet.Storage.Core.Models.NotificationQueue", b =>
                 {
                     b.Property<Guid>("Id")
@@ -161,6 +255,33 @@ namespace YPermitin.FIASToolSet.Storage.PostgreSQL.Migrations
                             Id = new Guid("749041e9-f51d-48b7-abe0-14ba50436431"),
                             Name = "Custom"
                         });
+                });
+
+            modelBuilder.Entity("YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallation", b =>
+                {
+                    b.HasOne("YPermitin.FIASToolSet.Storage.Core.Models.FIASVersion", "FIASVersion")
+                        .WithMany()
+                        .HasForeignKey("FIASVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationType", "InstallationType")
+                        .WithMany()
+                        .HasForeignKey("InstallationTypeId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("YPermitin.FIASToolSet.Storage.Core.Models.FIASVersionInstallationStatus", "Status")
+                        .WithMany()
+                        .HasForeignKey("StatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("FIASVersion");
+
+                    b.Navigation("InstallationType");
+
+                    b.Navigation("Status");
                 });
 
             modelBuilder.Entity("YPermitin.FIASToolSet.Storage.Core.Models.NotificationQueue", b =>

--- a/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/ServiceRegistration.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/ServiceRegistration.cs
@@ -20,6 +20,7 @@ namespace YPermitin.FIASToolSet.Storage.PostgreSQL
             });
 
             services.AddScoped<IFIASMaintenanceRepository, FIASMaintenanceRepository>();
+            services.AddScoped<IFIASInstallationManagerRepository, FIASInstallationManagerRepository>();
         }
     }
 }

--- a/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/Services/FIASInstallationManagerRepository.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.PostgreSQL/Services/FIASInstallationManagerRepository.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using YPermitin.FIASToolSet.Storage.Core.Models;
+using YPermitin.FIASToolSet.Storage.Core.Services;
+using YPermitin.FIASToolSet.Storage.PostgreSQL.DbContexts;
+
+namespace YPermitin.FIASToolSet.Storage.PostgreSQL.Services;
+
+public class FIASInstallationManagerRepository : CommonRepository, IFIASInstallationManagerRepository
+{
+    public FIASInstallationManagerRepository(FIASToolSetServiceContext context) : base(context)
+    {
+    }
+
+    public async Task<List<FIASVersionInstallation>> GetInstallations(Guid? statusId = null, Guid? typeId = null)
+    {
+        var query = _context.FIASVersionInstallations.AsQueryable();
+
+        if (statusId != null)
+        {
+            query = query.Where(e => e.StatusId == statusId);
+        }
+        
+        if (typeId != null)
+        {
+            query = query.Where(e => e.InstallationTypeId == typeId);
+        }
+
+        var result = await query.OrderBy(e => e.Created).ToListAsync();
+
+        return result;
+    }
+
+    public async Task<FIASVersionInstallation> GetInstallation(Guid id)
+    {
+        return await _context.FIASVersionInstallations
+            .FirstOrDefaultAsync(e => e.Id == id);
+    }
+
+    public async Task<FIASVersionInstallation> GetLastInstallation()
+    {
+        var query = _context.FIASVersionInstallations
+            .Where(e => e.Created == _context.FIASVersionInstallations.Max(e => e.Created))
+            .AsQueryable();
+
+        return await query.FirstOrDefaultAsync();
+    }
+
+    public async Task<FIASVersionInstallation> GetPreviousInstallation(Guid installationId)
+    {
+        var lastVersionQuery = _context.FIASVersionInstallations
+            .AsNoTracking()
+            .Where(lv => lv.Id != installationId
+                         && lv.Created <= _context.FIASVersionInstallations
+                             .Where(lvm => lvm.Id == installationId)
+                             .Max(lvm => lvm.Created)
+            )
+            .OrderByDescending(lv => lv.Created)
+            .AsQueryable();
+
+        var lastVersion = await lastVersionQuery.FirstOrDefaultAsync();
+
+        return lastVersion;
+    }
+
+    public void AddInstallation(FIASVersionInstallation installation)
+    {
+        _context.Entry(installation).State = EntityState.Added;
+    }
+
+    public void UpdateInstallation(FIASVersionInstallation installation)
+    {
+        _context.Entry(installation).State = EntityState.Modified;
+    }
+}

--- a/Libs/YPermitin.FIASToolSet.Storage.SQLServer/DbContexts/FIASToolSetServiceContext.cs
+++ b/Libs/YPermitin.FIASToolSet.Storage.SQLServer/DbContexts/FIASToolSetServiceContext.cs
@@ -10,6 +10,10 @@ namespace YPermitin.FIASToolSet.Storage.SQLServer.DbContexts
         public DbSet<NotificationQueue> NotificationsQueues { get; set; }
         public DbSet<NotificationStatus> NotificationsStatuses { get; set; }
 
+        public DbSet<FIASVersionInstallationStatus> FIASVersionInstallationStatuses { get; set; }
+        public DbSet<FIASVersionInstallation> FIASVersionInstallations { get; set; }
+        public DbSet<FIASVersionInstallationType> FIASVersionInstallationsTypes { get; set; }
+        
         private FIASToolSetServiceContext()
         {
         }
@@ -105,6 +109,66 @@ namespace YPermitin.FIASToolSet.Storage.SQLServer.DbContexts
             modelBuilder.Entity<FIASVersion>()
                 .Property(e => e.TextVersion)
                 .HasMaxLength(50);
+
+            #endregion
+            
+            #region FIASVersionInstallationStatus
+
+            modelBuilder.Entity<FIASVersionInstallationStatus>()
+                .HasKey(e => e.Id);
+            modelBuilder.Entity<FIASVersionInstallationStatus>()
+                .HasIndex(e => new { e.Name });
+            modelBuilder.Entity<FIASVersionInstallationStatus>()
+                .HasData(new List<FIASVersionInstallationStatus>()
+                {
+                    new()
+                    {
+                        Id = FIASVersionInstallationStatus.New,
+                        Name = "New"
+                    },
+                    new()
+                    {
+                        Id = FIASVersionInstallationStatus.Installing,
+                        Name = "Installing"
+                    },
+                    new()
+                    {
+                        Id = FIASVersionInstallationStatus.Installed,
+                        Name = "Installed"
+                    }
+                });
+
+            #endregion
+            
+            #region FIASVersionInstallation
+            
+            modelBuilder.Entity<FIASVersionInstallation>()
+                .HasKey(e => e.Id);
+            modelBuilder.Entity<FIASVersionInstallation>()
+                .HasIndex(e => new { e.StatusId, e.Created, e.Id });
+
+            #endregion
+            
+            #region FIASVersionInstallationType
+            
+            modelBuilder.Entity<FIASVersionInstallationType>()
+                .HasKey(e => e.Id);
+            modelBuilder.Entity<FIASVersionInstallationType>()
+                .HasIndex(e => new { e.Id });
+            modelBuilder.Entity<FIASVersionInstallationType>()
+                .HasData(new List<FIASVersionInstallationType>()
+                {
+                    new()
+                    {
+                        Id = FIASVersionInstallationType.Full,
+                        Name = "Full"
+                    },
+                    new()
+                    {
+                        Id = FIASVersionInstallationType.Update,
+                        Name = "Update"
+                    }
+                });
 
             #endregion
         }

--- a/Web/YPermitin.FIASToolSet.API/Properties/launchSettings.json
+++ b/Web/YPermitin.FIASToolSet.API/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "",
-      "applicationUrl": "https://localhost:7289;http://localhost:5289",
+      "applicationUrl": "http://localhost:5289",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- Добавлено хранение версий ФИАС для установки, с типом установки и статусом установки. Обновление таблицы выполняется при изменении информации о версиях.
- Добавлены сущности типа установки, статуса установки и информации об установке версии ФИАС
- Добавлена полная поддержка новой версии базы для PostgreSQL. Для SQL Server подготовка изменений.
- Обновление стартовых настроек приложения